### PR TITLE
create cache database for chainwork calculation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -361,6 +361,7 @@ libmateable_node_a_SOURCES = \
   blockencodings.cpp \
   blockfilter.cpp \
   chain.cpp \
+  chainworkdb.cpp \
   consensus/tx_verify.cpp \
   crypto/algo_sanity.cpp \
   crypto/algo_sanity.h \

--- a/src/chainworkdb.cpp
+++ b/src/chainworkdb.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 barrystyle
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainworkdb.h>
+
+ChainworkDB chainwork_db(GetDefaultDataDir() / "chainworkdb", 4194304, false, false);
+
+ChainworkDB::ChainworkDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe) :
+    db(ldb_path, nCacheSize, fMemory, fWipe, true)
+{}
+
+bool ChainworkDB::HaveEntry(const int& height) const {
+    return db.Exists(height);
+}
+
+void ChainworkDB::GetEntry(const int& height, arith_uint256& chainWork) const {
+    uint256 temp{};
+    db.Read(height, temp);
+    chainWork = UintToArith256(temp);
+}
+
+void ChainworkDB::WriteEntry(const int& height, arith_uint256& chainWork) {
+    uint256 temp{};
+    temp = ArithToUint256(chainWork);
+    db.Write(height, temp);
+}

--- a/src/chainworkdb.h
+++ b/src/chainworkdb.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 barrystyle
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef CHAINWORKDB_H
+#define CHAINWORKDB_H
+
+#include <arith_uint256.h>
+#include <dbwrapper.h>
+#include <uint256.h>
+#include <validation.h>
+
+class ChainworkDB
+{
+protected:
+    CDBWrapper db;
+
+public:
+    explicit ChainworkDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe);
+
+    bool HaveEntry(const int& height) const;
+    void GetEntry(const int& height, arith_uint256& chainWork) const;
+    void WriteEntry(const int& height, arith_uint256& chainWork);
+};
+
+extern ChainworkDB chainwork_db;
+
+#endif // CHAINWORKDB_H


### PR DESCRIPTION
MateableCoin calculates the 'average chainwork' per block while loading the blockindex into memory, on each client launch. This is both repetitive and time consuming, as the calculation required is quite heavy.

Instead, we calculate this figure once, store it in a database and simply read from the database on each subsequent launch.