### PR TITLE
Update wallet:: To support announcements, improve fetch price, Set Yescrypt MinimumChainWork.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -473,6 +473,7 @@ libmateable_wallet_a_SOURCES = \
   wallet/external_signer_scriptpubkeyman.cpp \
   wallet/feebumper.cpp \
   wallet/fees.cpp \
+  wallet/fetch.cpp \
   wallet/interfaces.cpp \
   wallet/load.cpp \
   wallet/receive.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -50,7 +50,6 @@ QT_MOC_CPP = \
   qt/moc_coincontroltreewidget.cpp \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_editaddressdialog.cpp \
-  qt/moc_fetch.cpp \
   qt/moc_guiutil.cpp \
   qt/moc_initexecutor.cpp \
   qt/moc_intro.cpp \
@@ -122,7 +121,6 @@ BITCOIN_QT_H = \
   qt/createwalletdialog.h \
   qt/csvmodelwriter.h \
   qt/editaddressdialog.h \
-  qt/fetch.h \
   qt/guiconstants.h \
   qt/guiutil.h \
   qt/initexecutor.h \
@@ -258,7 +256,6 @@ BITCOIN_QT_WALLET_CPP = \
   qt/coincontroltreewidget.cpp \
   qt/createwalletdialog.cpp \
   qt/editaddressdialog.cpp \
-  qt/fetch.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \
   qt/paymentserver.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -123,8 +123,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
 
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000002dfa96cf7b4300d");  //block 2500000
-        consensus.defaultAssumeValid = uint256S("0x7f5e46e925f98d74ff7b19902f334dcba22f23f8bc360686c27888726a1d1b95");  //block 2500000 
+        consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000002dfa95b2102058d");  //yescrypt
+        consensus.defaultAssumeValid = uint256S("0x7f5e46e925f98d74ff7b19902f334dcba22f23f8bc360686c27888726a1d1b95");  //block 2500000
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.

--- a/src/qt/fetch.h
+++ b/src/qt/fetch.h
@@ -1,6 +1,0 @@
-#ifndef FETCH_H
-#define FETCH_H
-
-void return_random_exchange(std::string& exchangeData);
-
-#endif // FETCH_H

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -34,6 +34,31 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="AnnouncementData">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+<property name="styleSheet">
+ <string notr="true">
+  QLabel {
+    background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488);
+    color: #000000;
+    qproperty-alignment: 'AlignCenter';
+  }
+ </string>
+</property>     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="margin">
+      <number>3</number>
+     </property>
+     <property name="text">
+
+     </property>
+    </widget>
+   </item>
+
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1,0">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -7,7 +7,7 @@
 
 #include <qt/bitcoinunits.h>
 #include <qt/clientmodel.h>
-#include <qt/fetch.h>
+#include <wallet/fetch.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
@@ -145,7 +145,9 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
     walletModel(nullptr),
     m_platform_style{platformStyle},
     txdelegate(new TxViewDelegate(platformStyle, this)),
-    priceUpdateTimer(new QTimer(this))  // Initialize the timer
+    priceUpdateTimer(new QTimer(this)),  // Initialize the timer
+    announcementUpdateTimer(new QTimer(this))  // Initialize the timer
+
 {
     ui->setupUi(this);
 
@@ -297,6 +299,13 @@ void OverviewPage::setWalletModel(WalletModel *model)
     // Start the timer with a 60-second interval
     priceUpdateTimer->start(60000);  // 60000 ms = 60 seconds
     setPriceData();
+  // Connect the timer's timeout signal to setAnnouncementData
+    connect(announcementUpdateTimer, &QTimer::timeout, this, &OverviewPage::setAnnouncementData);
+
+    // Start the timer with a 60-second interval
+    announcementUpdateTimer->start(60000);  // 60000 ms = 60 seconds
+    setAnnouncementData();
+
 }
 
 void OverviewPage::changeEvent(QEvent* e)
@@ -315,6 +324,19 @@ void OverviewPage::setPriceData()
     std::string newPriceData;
     return_random_exchange(newPriceData);
     this->ui->priceData->setText(QString::fromStdString(newPriceData));
+}
+
+void OverviewPage::setAnnouncementData()
+{
+    std::string annText;
+    if (parse_wallet_announcement(annText) && !annText.empty()) {
+        QString htmlText = QString("<img src=\":/icons/warning\" width=\"24\" height=\"24\" style=\"vertical-align:middle;\"> "
+                                   "<b>%1</b>").arg(QString::fromStdString(annText));
+        ui->AnnouncementData->setText(htmlText);
+        ui->AnnouncementData->setVisible(true);
+    } else {
+        ui->AnnouncementData->setVisible(false);
+    }
 }
 
 void OverviewPage::updateDisplayUnit()

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -32,8 +32,10 @@ class OverviewPage : public QWidget
 public:
     explicit OverviewPage(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
     ~OverviewPage();
-QTimer *priceUpdateTimer;  // Declare the QTimer
+    QTimer *priceUpdateTimer;  // Declare the QTimer
+    QTimer *announcementUpdateTimer;  // Declare the QTimer
     void setPriceData();
+    void setAnnouncementData();
     void setClientModel(ClientModel *clientModel);
     void setWalletModel(WalletModel *walletModel);
     void showOutOfSyncWarning(bool fShow);

--- a/src/wallet/fetch.cpp
+++ b/src/wallet/fetch.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2024-2025 The Mateable Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/fetch.h>
 #include <stdlib.h>
 #include <time.h>
 #include <boost/beast/core.hpp>
@@ -107,4 +112,64 @@ void return_random_exchange(std::string& exchangeData)
         }
     }
 }
+// Fetch wallet announcement
+bool fetch_wallet_announcement(std::string& outstr)
+{
+    try
+    {
+        const char* host = "50.116.31.124";
+        const char* port = "80";
 
+        boost::asio::io_context ioc;
+        boost::beast::net::ip::tcp::resolver resolver(ioc);
+        boost::beast::tcp_stream stream(ioc);
+
+        auto const results = resolver.resolve(host, port);
+        stream.connect(results);
+
+        boost::beast::http::request<boost::beast::http::string_body> req{boost::beast::http::verb::get, "/announcement", int(10)};
+        req.set(boost::beast::http::field::host, host);
+        req.set(boost::beast::http::field::user_agent, "mateable/1.0");
+
+        boost::beast::http::write(stream, req);
+        boost::beast::flat_buffer buffer;
+        boost::beast::http::response<boost::beast::http::dynamic_body> res;
+        boost::beast::http::read(stream, buffer, res);
+
+        std::stringstream ss;
+        ss << res;
+        outstr = ss.str();
+
+        boost::beast::error_code ec;
+        stream.socket().shutdown(boost::beast::net::ip::tcp::socket::shutdown_both, ec);
+    }
+    catch (std::exception const& e)
+    {
+        return false;
+    }
+    return true;
+}
+
+// Parse the wallet announcement
+bool parse_wallet_announcement(std::string& announcementText)
+{
+    std::string outstr;
+    if (!fetch_wallet_announcement(outstr)) {
+        return false;
+    }
+
+    bool parse_begin = false;
+    std::istringstream instr(outstr);
+    for (std::string line; std::getline(instr, line); )
+    {
+        if (line.find("start") != std::string::npos) {
+            parse_begin = true;
+            continue;
+        }
+        if (parse_begin && !line.empty()) {
+            announcementText = line;
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/wallet/fetch.h
+++ b/src/wallet/fetch.h
@@ -1,0 +1,12 @@
+// Copyright (c) 2024-2025 The Mateable Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef FETCH_H
+#define FETCH_H
+
+#include <string>
+
+void return_random_exchange(std::string& exchangeData);
+bool parse_wallet_announcement(std::string& announcementText);
+#endif // FETCH_H

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -13,6 +13,7 @@
 #include <wallet/rpc/wallet.h>
 #include <wallet/rpc/util.h>
 #include <wallet/wallet.h>
+#include <wallet/fetch.h>
 
 #include <optional>
 
@@ -60,6 +61,8 @@ static RPCHelpMan getwalletinfo()
                         }, /*skip_type_check=*/true},
                         {RPCResult::Type::BOOL, "descriptors", "whether this wallet uses descriptors for scriptPubKey management"},
                         {RPCResult::Type::BOOL, "external_signer", "whether this wallet is configured to use an external signer such as a hardware wallet"},
+                        {RPCResult::Type::STR_AMOUNT, "current_price", "Current market price"},
+                        {RPCResult::Type::STR, "announcement", "wallet announcement"},
                     }},
                 },
                 RPCExamples{
@@ -122,7 +125,21 @@ static RPCHelpMan getwalletinfo()
     }
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     obj.pushKV("external_signer", pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
-    return obj;
+        // Fetch and add current price
+    std::string exchangeData;
+    return_random_exchange(exchangeData);
+
+size_t pos = exchangeData.find("usd");
+if (pos != std::string::npos) {
+    exchangeData = exchangeData.substr(pos + 3); // Skip "usd"
+    exchangeData.erase(0, exchangeData.find_first_not_of(" \t")); // Trim leading spaces
+}
+    obj.pushKV("current_price", exchangeData);
+std::string announcement;
+if (parse_wallet_announcement(announcement)) {
+    obj.pushKV("announcement", announcement);
+}
+   return obj;
 },
     };
 }
@@ -756,6 +773,63 @@ static RPCHelpMan migratewallet()
     };
 }
 
+static RPCHelpMan getprice()
+{
+    return RPCHelpMan{"getprice",
+        "\nReturns the current market price.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "price", "The current price as a string"},
+            }
+        },
+        RPCExamples{
+            HelpExampleCli("getprice", "")
+            + HelpExampleRpc("getprice", "")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        {
+            std::string exchangeData;
+            return_random_exchange(exchangeData);
+
+size_t pos = exchangeData.find("usd");
+if (pos != std::string::npos) {
+    exchangeData = exchangeData.substr(pos + 3); // Skip "usd"
+    exchangeData.erase(0, exchangeData.find_first_not_of(" \t")); // Trim leading spaces
+}
+
+            UniValue r(UniValue::VOBJ);
+            r.pushKV("price", exchangeData);
+            return r;
+        }
+    };
+}
+
+static RPCHelpMan getannouncement()
+{
+    return RPCHelpMan{"getannouncement",
+        "Returns the current announcement if available.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::STR, "announcement", "The announcement text"
+        },
+        RPCExamples{
+            HelpExampleCli("getannouncement", "")
+            + HelpExampleRpc("getannouncement", "")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        {
+            std::string announcement;
+            if (parse_wallet_announcement(announcement)) {
+                return UniValue(announcement);
+            } else {
+                return UniValue(""); // or "No announcement" if you prefer
+            }
+        },
+    };
+}
+
 // addresses
 RPCHelpMan getaddressinfo();
 RPCHelpMan getnewaddress();
@@ -893,6 +967,9 @@ Span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &unloadwallet},
         {"wallet", &upgradewallet},
         {"wallet", &walletcreatefundedpsbt},
+        { "wallet", &getprice },
+        { "wallet", &getannouncement },
+
 #ifdef ENABLE_EXTERNAL_SIGNER
         {"wallet", &walletdisplayaddress},
 #endif // ENABLE_EXTERNAL_SIGNER


### PR DESCRIPTION
This PR includes the following updates:

- Set `consensus.nMinimumChainWork` to the Yescrypt-specific value for block 2,500,000 to ensure mining pool compatibility.
- Add support for fetching announcements from the database, so messages appear automatically in all wallets.
- Improve fetching price  also was added to the rpc 
