### PR TITLE
crypto: fix Ghostrider build failures on Ubuntu 22 

### DIFF
--- a/src/crypto/ghostrider/cryptonote/int-util.h
+++ b/src/crypto/ghostrider/cryptonote/int-util.h
@@ -133,6 +133,14 @@ static inline uint64_t div128_64(uint64_t dividend_hi, uint64_t dividend_lo, uin
 #define IDENT32(x) ((uint32_t) (x))
 #define IDENT64(x) ((uint64_t) (x))
 
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
+#define SWAP32LE(x) SWAP32(x)
+#define SWAP64LE(x) SWAP64(x)
+#else
+#define SWAP32LE(x) ((uint32_t)(x))
+#define SWAP64LE(x) ((uint64_t)(x))
+#endif
+
 #define SWAP32(x) ((((uint32_t) (x) & 0x000000ff) << 24) | \
   (((uint32_t) (x) & 0x0000ff00) <<  8) | \
   (((uint32_t) (x) & 0x00ff0000) >>  8) | \

--- a/src/crypto/ghostrider/cryptonote/skein_port.h
+++ b/src/crypto/ghostrider/cryptonote/skein_port.h
@@ -93,9 +93,7 @@ typedef uint64_t        u64b_t;             /* 64-bit unsigned integer */
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 #  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
-#endif
-
-#if BYTE_ORDER == BIG_ENDIAN
+#elif BYTE_ORDER == BIG_ENDIAN
 #  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
 #endif
 


### PR DESCRIPTION
  Fixes two build issues in the Ghostrider/CryptoNote crypto code reported on Ubuntu 22.04.

  Changes:
  - int-util.h — Add missing SWAP64LE and SWAP32LE macros. On little-endian (x86/x86-64) these are no-ops; on big-endian they byte-swap.
  - skein_port.h — Fix PLATFORM_BYTE_ORDER redefinition warning caused by two separate #if blocks both evaluating when BYTE_ORDER is undefined. Changed to 
  #if/#elif.
                                                                                                                                                           
  Testing:                                                  
  - Built successfully on Ubuntu 22.04 