### PR TITLE
build: fix crypto build warnings for cross-platform compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -473,6 +473,7 @@ if test "$CXXFLAGS_overridden" = "no"; then
   dnl set the -Wno-foo case if it works.
   AX_CHECK_COMPILE_FLAG([-Wunused-parameter], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-parameter"], [], [$CXXFLAG_WERROR])
   AX_CHECK_COMPILE_FLAG([-Wself-assign], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-self-assign"], [], [$CXXFLAG_WERROR])
+  AX_CHECK_COMPILE_FLAG([-Wmacro-redefined], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-macro-redefined"], [], [$CXXFLAG_WERROR])
   if test "$suppress_external_warnings" != "yes" ; then
     AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"], [], [$CXXFLAG_WERROR])
   fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ print-%: FORCE
 DIST_SUBDIRS = secp256k1
 
 AM_LDFLAGS = $(LIBTOOL_LDFLAGS) $(HARDENED_LDFLAGS) $(GPROF_LDFLAGS) $(SANITIZER_LDFLAGS) $(LTO_LDFLAGS) $(CORE_LDFLAGS)
-AM_CXXFLAGS = $(DEBUG_CXXFLAGS) $(HARDENED_CXXFLAGS) $(WARN_CXXFLAGS) $(NOWARN_CXXFLAGS) $(ERROR_CXXFLAGS) $(GPROF_CXXFLAGS) $(SANITIZER_CXXFLAGS) $(LTO_CXXFLAGS) $(CORE_CXXFLAGS) -Wno-unused-variable -Wno-extra -Wno-return-type -Wno-macro-redefined -Wno-deprecated-declarations -Wno-pointer-arith
+AM_CXXFLAGS = $(DEBUG_CXXFLAGS) $(HARDENED_CXXFLAGS) $(WARN_CXXFLAGS) $(NOWARN_CXXFLAGS) $(ERROR_CXXFLAGS) $(GPROF_CXXFLAGS) $(SANITIZER_CXXFLAGS) $(LTO_CXXFLAGS) $(CORE_CXXFLAGS) -Wno-unused-variable -Wno-extra -Wno-return-type -Wno-deprecated-declarations -Wno-pointer-arith
 AM_CFLAGS = $(DEBUG_CFLAGS) $(HARDENED_CFLAGS) $(WARN_CFLAGS) $(NOWARN_CFLAGS) $(ERROR_CFLAGS) $(GPROF_CFLAGS) $(SANITIZER_CFLAGS) $(LTO_CFLAGS) $(CORE_CFLAGS) -Wno-unused-variable -Wno-extra -Wno-implicit-function-declaration -Wno-deprecated-declarations -Wno-format -Wno-cpp
 AM_CPPFLAGS = $(DEBUG_CPPFLAGS) $(HARDENED_CPPFLAGS) $(CORE_CPPFLAGS)
 AM_LIBTOOLFLAGS = --preserve-dup-deps

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -463,7 +463,7 @@ endif
 # wallet: shared between bitcoind and bitcoin-qt, but only linked
 # when wallet enabled
 libmateable_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS) $(BDB_CPPFLAGS) $(SQLITE_CFLAGS)
-libmateable_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+libmateable_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) -Wno-nonnull
 libmateable_wallet_a_SOURCES = \
   wallet/coincontrol.cpp \
   wallet/context.cpp \

--- a/src/crypto/ghostrider/cryptonote/slow-hash.c
+++ b/src/crypto/ghostrider/cryptonote/slow-hash.c
@@ -20,6 +20,13 @@
 #include <crypto/ghostrider/cryptonote/int-util.h>
 #include <crypto/ghostrider/cryptonote/variant2_int_sqrt.h>
 
+#ifndef SWAP64LE
+#define SWAP64LE(x) ((uint64_t)(x))
+#endif
+#ifndef SWAP32LE
+#define SWAP32LE(x) ((uint32_t)(x))
+#endif
+
 #if defined(_MSC_VER)
 #include <malloc.h>
 #endif

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -11,6 +11,7 @@
 // See: https://github.com/boostorg/process/issues/235
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
+#pragma GCC diagnostic ignored "-Wunused-result"
 #endif
 #include <boost/process.hpp>
 #if defined(__GNUC__)


### PR DESCRIPTION
   ## Summary

   - Guard `-Wno-macro-redefined` behind a configure-time compiler probe so it is only applied when the compiler supports it
   - Suppress Boost `-Wnonnull` and `-Wunused-result` warnings that produce noise on newer compilers
   - Add fallback `SWAP64LE`/`SWAP32LE` guards in `slow-hash.c` to fix builds on platforms where these macros are not defined

